### PR TITLE
Update permission handling and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Apple Notes Exporter is a macOS application designed to export notes from the Ap
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/yourusername/apple-notes-expoerter.git
+   git clone https://github.com/mrsarac/apple-notes-expoerter.git
    ```
 
 2. Open the project in Xcode:
@@ -56,10 +56,12 @@ Apple Notes Exporter is a macOS application designed to export notes from the Ap
 
 - Ensure you have the necessary permissions to write to the selected export directory.
 - If you encounter permission errors, try adjusting the directory permissions using the terminal.
+- The `PermissionChecker` class checks directory permissions to ensure the selected export location is writable.
+- The `checkAndCreateDirectory` method in `NotesExporter.swift` handles specific permission errors and provides detailed error messages.
 
 ## Contributing
 
-Contributions are welcome! Please fork the repository and submit a pull request for any improvements or bug fixes.
+Contributions are welcome! Please fork the repository and submit a pull request for any improvements or bug fixes. If you encounter any issues, please submit them via the repository's issue tracker.
 
 ## License
 

--- a/apple-notes-expoerter/ContentView.swift
+++ b/apple-notes-expoerter/ContentView.swift
@@ -134,7 +134,7 @@ struct ContentView: View {
             } catch NotesExportError.permissionDenied(let message) {
                 print("Error: Permission denied - \(message)")
                 await MainActor.run {
-                    alertMessage = "Permission denied: \(message)"
+                    alertMessage = "Permission denied: \(message)\nPlease ensure you have write permissions for the selected location, or try selecting a different export location."
                     showAlert = true
                     isExporting = false
                 }

--- a/apple-notes-expoerter/Services/PermissionChecker.swift
+++ b/apple-notes-expoerter/Services/PermissionChecker.swift
@@ -73,6 +73,8 @@ struct FilePermissions {
             info.append("  1. Check parent directory permissions")
             info.append("  2. Verify disk mounting options")
             info.append("  3. Check for extended attributes: ls -le '\(path)'")
+            info.append("  4. Ensure the directory is not locked: chflags nouchg '\(path)'")
+            info.append("  5. Check for ACLs: ls -le '\(path)' and remove if necessary: chmod -N '\(path)'")
         }
         
         return info.joined(separator: "\n")


### PR DESCRIPTION
Update the interface for exporting notes and handle permission errors.

* **README.md**
  - Add a section about handling permission errors in the "Troubleshooting" section.
  - Mention the `PermissionChecker` class and its role in checking directory permissions.
  - Mention the `checkAndCreateDirectory` method in `NotesExporter.swift` and its role in handling permission errors.

* **ContentView.swift**
  - Update the `exportNotes` function to handle `NotesExportError.permissionDenied` and update the alert message.
  - Add a detailed error message for `NotesExportError.permissionDenied` in the alert.

* **PermissionChecker.swift**
  - Update the `generateTroubleshootingInfo` method to provide detailed troubleshooting steps.
  - Add more detailed error messages in the `checkPermissions` method.

